### PR TITLE
Change datasource name format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ import (
     "github.com/go-xorm/xorm"
 )
 
+//The formate of DataSource name is store://uri/dbname
 // for goleveldb as store
-xorm.NewEngine("tidb", "goleveldb://./tidb")
+xorm.NewEngine("tidb", "goleveldb://./tidb/tidb")
 // for memory as store
-xorm.NewEngine("tidb", "memory://tidb")
+xorm.NewEngine("tidb", "memory://tidb/tidb")
 // for boltdb as store
-xorm.NewEngine("tidb", "boltdb://./tidb")
+xorm.NewEngine("tidb", "boltdb://./tidb/tidb")
 ```

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -31,7 +31,7 @@ func newTidbDriverDB(storeType string) (*sql.DB, error) {
 	}
 
 	os.Remove("./tidb_" + storeType)
-	return sql.Open("tidb", storeType+"://./tidb_"+storeType+"tidb")
+	return sql.Open("tidb", storeType+"://./tidb_"+storeType+"/tidb")
 }
 
 func newCache() core.Cacher {

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -18,20 +18,20 @@ var showTestSql = true
 
 func newTidbEngine(storeType string) (*xorm.Engine, error) {
 	if storeType == "memory" {
-		return xorm.NewEngine("tidb", storeType+"://tidb")
+		return xorm.NewEngine("tidb", storeType+"://tidb/tidb")
 	}
 
-	os.Remove("./tidb_"+storeType)
-	return xorm.NewEngine("tidb", storeType+"://./tidb_"+storeType)
+	os.Remove("./tidb_" + storeType)
+	return xorm.NewEngine("tidb", storeType+"://./tidb_"+storeType+"/tidb")
 }
 
 func newTidbDriverDB(storeType string) (*sql.DB, error) {
 	if storeType == "memory" {
-		return sql.Open("tidb", storeType+"://./tidb")
+		return sql.Open("tidb", storeType+"://./tidb/tidb")
 	}
 
-	os.Remove("./tidb_"+storeType)
-	return sql.Open("tidb", storeType+"://./tidb_"+storeType)
+	os.Remove("./tidb_" + storeType)
+	return sql.Open("tidb", storeType+"://./tidb_"+storeType+"tidb")
 }
 
 func newCache() core.Cacher {
@@ -139,15 +139,15 @@ const (
 
 func BenchmarkTidbDriverInsert(t *testing.B) {
 	tests.DoBenchDriver(func() (*sql.DB, error) {
-			return newTidbDriverDB("goleveldb")
-		}, createTableQl, dropTableQl,
+		return newTidbDriverDB("goleveldb")
+	}, createTableQl, dropTableQl,
 		tests.DoBenchDriverInsert, t)
 }
 
 func BenchmarkTidbDriverFind(t *testing.B) {
 	tests.DoBenchDriver(func() (*sql.DB, error) {
-			return newTidbDriverDB("goleveldb")
-		}, createTableQl, dropTableQl,
+		return newTidbDriverDB("goleveldb")
+	}, createTableQl, dropTableQl,
 		tests.DoBenchDriverFind, t)
 }
 


### PR DESCRIPTION
We have changed TiDB datasource name format to store://datapath/dbname. So the dbname does not have to be the same with datapath. And datapath part will be passed to store engine as uri.
